### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dastardly.yml
+++ b/.github/workflows/dastardly.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   dastardly-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vvoffsec/f1-forum-app/security/code-scanning/1](https://github.com/vvoffsec/f1-forum-app/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to explicitly define the least privileges required. Since the workflow involves checking out code and performing a scan, it only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` is limited to read-only access to the repository contents, reducing the risk of unintended modifications.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
